### PR TITLE
Allow the user to export the DB schema as MD file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 # rspec failure tracking
 .rspec_status
 database_documenter-*.gem
+
+# RubyMine Configs
+.idea/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to Database Documenter gem! We created this gem to generate database doc
 
 ## Features
 
-1. Generate database documentation as a Word document.
+1. Generate database documentation as a `Word document` or `Markdown file`.
 2. Generate Description for columns based on it is type and name, Also handle Enums and STI and AASM.
 3. Easy to change the generated description by adding a comment on your database.
 4. Hide sample values of desired columns using configuration.
@@ -39,9 +39,17 @@ end
 
 ## Usage
 
-in the application folder run this rake task and then you will found word document named `database.docx` in your application folder:
+### To Generate the Word document
+
+In the application directory run this rake task and then you will find a word document named `database.docx` in your application directory:
 
     $ bundle exec rake generate_db_document
+
+### To Generate the Markdown file
+
+Run the following rake task and then you will find a markdown file named `database.md` in your application directory:
+
+    $ bundle exec rake generate_db_md_document
 
 ## Override generated description
 You can override it by adding comment to your schema using one of the following options:
@@ -63,3 +71,4 @@ use `change_column_comment` and `change_table_comment` methods in rails 5
 
 - Generate the ERD with the file.
 - Add test cases.
+- Update `DatabaseDocumenter::TableDat`a to return the `sql_code` as a `String`.

--- a/lib/database_documenter.rb
+++ b/lib/database_documenter.rb
@@ -7,7 +7,9 @@ require 'database_documenter/database_comment/postgres_database_comment'
 require 'database_documenter/tables_sql'
 require 'database_documenter/column_description'
 require 'database_documenter/table_data'
+require 'database_documenter/exporters/base_exporter'
 require 'database_documenter/exporters/export_to_word'
+require 'database_documenter/exporters/export_to_md'
 require 'caracal'
 require "database_documenter/railtie" if defined?(Rails)
 

--- a/lib/database_documenter/exporters/base_exporter.rb
+++ b/lib/database_documenter/exporters/base_exporter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module DatabaseDocumenter::Exporters
+  class BaseExporter
+    attr_accessor :table_data, :printed_tables, :generated_cols_count, :commented_cols_count
+
+    APP_NAME = ENV['APP_NAME'].capitalize
+    HEADER_SECOND_LINE = "The database design specifies how the data of the software is going to be stored."
+
+    def initialize
+      self.table_data = DatabaseDocumenter::TableData.new
+      self.printed_tables = []
+      self.generated_cols_count = 0
+      self.commented_cols_count = 0
+    end
+
+    def load_all_models
+      Rails.application.eager_load!
+    end
+
+    # Skip STI classes
+    # Skip duplicate tables in case of has_and_belongs_to_many
+    # Skip certain modules
+    def skip_class?(klass)
+      (klass.class_name != klass.base_class.class_name) || klass.abstract_class? ||
+        (printed_tables.include? klass.table_name) || (DatabaseDocumenter.configuration.skipped_modules.include? klass.parent.name)
+    end
+  end
+end

--- a/lib/database_documenter/exporters/export_to_md.rb
+++ b/lib/database_documenter/exporters/export_to_md.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module DatabaseDocumenter::Exporters
+  class ExportToMd < BaseExporter
+    def call
+      load_all_models
+      generate_md_document
+    end
+
+    def generate_md_document
+      md_file_header = StringIO.new
+      md_file_body = StringIO.new
+      md_file = File.open("database.md", "w")
+
+      generate_md_file_header(md_file_header)
+
+      ActiveRecord::Base.descendants.each do |klass|
+        next if skip_class?(klass)
+
+        generate_table_metadata(md_file_header, md_file_body, klass)
+        generate_table_columns(md_file_body, klass)
+      end
+      md_file.puts md_file_header.string
+      md_file.puts md_file_body.string
+      md_file.close
+    end
+
+    def generate_md_file_header(md_file_header)
+      md_file_header << "# #{APP_NAME} Database Design\n"
+      md_file_header << "#{HEADER_SECOND_LINE}\n"
+      md_file_header << "# Tables \n"
+    end
+
+    def generate_table_metadata(md_file_header, md_file_body, klass)
+      metadata = table_data.get_meta_data(klass)
+
+      md_file_header << "- [#{klass.table_name}](##{klass.table_name})\n"
+
+      md_file_body << "\n"
+      md_file_body << "## #{klass.table_name}\n"
+      md_file_body << "### Table details\n"
+      md_file_body << "|Key|Value|\n"
+      md_file_body << "|---|---|\n"
+      md_file_body << "|Table Name|#{metadata[:name]}|\n"
+      md_file_body << "|Description|#{metadata[:description]}|\n"
+      md_file_body << "|Primary Key|#{metadata[:primary_key]}|\n"
+
+      md_file_body << "\n"
+
+      # TODO: Update DatabaseDocumenter::TableData to return this value as a String
+      # And let every Exporter renders it according to the required format
+      sql_code = metadata[:sql_code].contents.map(&:runs).map(&:first).map(&:text_content).join("\n")
+      md_file_body << "### Table SQL Code\n"
+      md_file_body << "```SQL\n"
+      md_file_body << "#{sql_code}\n"
+      md_file_body << "```\n"
+    end
+
+    def generate_table_columns(md_file_body, klass)
+      columns_data = table_data.get_columns_data(klass)
+
+      md_file_body << "### Table attributes\n"
+      md_file_body << "|Attribute|Description|Type|Example of values|\n"
+      md_file_body << "|---|---|---|---|\n"
+
+      columns_data.each do |col|
+        description = StringIO.new
+        col[:description].each do |column_description|
+          description << "- #{column_description}\n"
+        end
+        md_file_body.puts "|#{col[:name]}|#{col[:description][0]}|#{col[:type]}|#{col[:value]}|\n"
+      end
+      md_file_body.puts "\n"
+    end
+  end
+end

--- a/lib/database_documenter/exporters/export_to_word.rb
+++ b/lib/database_documenter/exporters/export_to_word.rb
@@ -1,23 +1,10 @@
 # frozen_string_literal: true
 
 module DatabaseDocumenter::Exporters
-  class ExportToWord
-    attr_accessor :table_data, :printed_tables, :generated_cols_count, :commented_cols_count
-
-    def initialize
-      self.table_data = DatabaseDocumenter::TableData.new
-      self.printed_tables = []
-      self.generated_cols_count = 0
-      self.commented_cols_count = 0
-    end
-
+  class ExportToWord < BaseExporter
     def call
       load_all_models
       generate_word_document
-    end
-
-    def load_all_models
-      Rails.application.eager_load!
     end
 
     def generate_word_document
@@ -26,9 +13,6 @@ module DatabaseDocumenter::Exporters
         add_word_footer(docx)
 
         ActiveRecord::Base.descendants.each do |klass|
-          # Skip STI classes
-          # Skip duplicate tables in case of has_and_belongs_to_many
-          # Skip certain modules
           next if skip_class?(klass)
 
           printed_tables << klass.table_name
@@ -51,8 +35,8 @@ module DatabaseDocumenter::Exporters
     end
 
     def add_word_header(docx)
-      docx.h1 "Database Design"
-      docx.p "The database design specifies how the data of the software is going to be stored."
+      docx.h1 "#{APP_NAME} Database Design"
+      docx.p HEADER_SECOND_LINE
     end
 
     def skip_class?(klass)

--- a/lib/database_documenter/railtie.rb
+++ b/lib/database_documenter/railtie.rb
@@ -1,6 +1,7 @@
 class DatabaseDocumenter::Railtie < Rails::Railtie
   rake_tasks do
     load 'tasks/generate_db_document.rake'
+    load 'tasks/generate_db_md_document.rake'
     load 'tasks/generate_dd_initializer.rake'
   end
 end

--- a/lib/tasks/generate_db_md_document.rake
+++ b/lib/tasks/generate_db_md_document.rake
@@ -1,0 +1,6 @@
+require "bundler/setup"
+require "database_documenter"
+
+task generate_db_md_document: :environment do
+  DatabaseDocumenter::Exporters::ExportToMd.new.call
+end


### PR DESCRIPTION
# Summary

Export to a `MS Word document` feature is useful to provide documentation for business. But I felt that we need to help our fellow developers by adding Export to `Markdown file` feature so they can include it in their project files to help the future developers.

So I've added another `rake` task `generate_db_md_document` and also refactored the old one `generate_db_document` a little bit.

# Output example

# {{APP_NAME}} Database Design
The database design specifies how the data of the software is going to be stored.
# Tables 
- [users](#users)
- [user_comments](#user_comments)

## users
### Table details
|Key|Value|
|---|---|
|Table Name|users|
|Description|The users table|
|Primary Key|id|

### Table SQL Code
```SQL
CREATE TABLE `users` (
 `id` bigint(20) NOT NULL AUTO_INCREMENT,
 `name` varchar(255) DEFAULT NULL,
 `created_at` datetime NOT NULL,
 `updated_at` datetime NOT NULL,
 PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8
```
### Table attributes
|Attribute|Description|Type|Example of values|
|---|---|---|---|
|id|Id of user|integer||
|name|The user full name|string||
|created_at|Date when the row was created|datetime||
|updated_at|Date when the row was updated|datetime||

## user_comments
### Table details
|Key|Value|
|---|---|
|Table Name|user_comments|
|Description|The user comments table|
|Primary Key|id|

... etc