### PR TITLE
Fix to tables corrupted design due to html code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ language: ruby
 cache: bundler
 rvm:
   - 2.5.1
-before_install: gem install bundler -v 1.17.3
+before_install: gem install bundler -v 2.1.4

--- a/lib/database_documenter/exporters/export_to_word.rb
+++ b/lib/database_documenter/exporters/export_to_word.rb
@@ -47,7 +47,7 @@ module DatabaseDocumenter::Exporters
     def generate_table_metadata(docx, klass)
       metadata = table_data.get_meta_data(klass)
       docx.p ''
-      docx.h2 "#{klass.table_name} schema"
+      docx.h2 klass.table_name.to_s
       docx.hr
 
       word_table = [

--- a/lib/database_documenter/table_data.rb
+++ b/lib/database_documenter/table_data.rb
@@ -58,10 +58,14 @@ class DatabaseDocumenter::TableData
                           elsif sample_record.nil?
                             ''
                           elsif Rails.version.split(".")[0].to_i == 4
-                            sample_record[col.name]
+                            clean_html_column_data(sample_record[col.name])
                           else
-                            sample_record.send("#{col.name}_before_type_cast")
+                            clean_html_column_data(sample_record.send("#{col.name}_before_type_cast"))
                           end
     column_data
+  end
+
+  def clean_html_column_data(column_data)
+    column_data.is_a?(String) ? column_data.gsub(/(?:\n\r?|\r\n?)/, '<br>').strip : column_data
   end
 end

--- a/lib/database_documenter/version.rb
+++ b/lib/database_documenter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DatabaseDocumenter
-  VERSION = '0.1.10'
+  VERSION = '0.1.11'
 end


### PR DESCRIPTION
Fix to html field break.
If DB table contains HTML code, all tables in word and md format got broken.